### PR TITLE
Publish fewer metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -38,11 +38,11 @@ func Start(source string) {
 	} else {
 		go librato.Librato(
 			metrics.DefaultRegistry,
-			10*time.Second,
+			15*time.Second,
 			"devops@shyp.com",
 			token,
 			source,
-			[]float64{0.5, 0.95, 0.99, 1},
+			[]float64{0.5, 0.99, 1},
 			time.Millisecond,
 		)
 	}
@@ -51,8 +51,8 @@ func Start(source string) {
 // Increment a counter with the given name.
 func Increment(name string) {
 	mn := getWithNamespace(name)
-	m := metrics.GetOrRegisterMeter(mn, nil)
-	m.Mark(1)
+	c := metrics.GetOrRegisterCounter(mn, nil)
+	c.Inc(1)
 	debug("increment %s 1", name)
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -26,7 +26,7 @@ func TestIncrementIncrements(t *testing.T) {
 	Increment("bar")
 	Increment("bar")
 	Increment("bar")
-	mn := metrics.GetOrRegisterMeter("bar", nil)
+	mn := metrics.GetOrRegisterCounter("bar", nil)
 	if mn.Count() != 3 {
 		t.Errorf("expected Count() to be 3, was %d", mn.Count())
 	}


### PR DESCRIPTION
Changes the reporting interval to 15 seconds, which drops our bill per metric
from $0.25/source/month to $0.20/source/month.

Meters publish a counter and also publish exponentially weighted moving
averages as Gauges, which are overkill and also increase the number of metrics
we're sending to Librato. Instead just send a Counter; I think I had it like
this initially because I was troubleshooting the metric displays as part of
a separate problem.
